### PR TITLE
Remove dispense drug from menu

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7944,8 +7944,7 @@
         "@emotion/use-insertion-effect-with-fallbacks": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.1.0.tgz",
-            "integrity": "sha512-+wBOcIV5snwGgI2ya3u99D7/FJquOIniQT1IKyDsBmEgwvpxMNeS65Oib7OnE2d2aY+3BU4OiH+0Wchf8yk3Hw==",
-            "requires": {}
+            "integrity": "sha512-+wBOcIV5snwGgI2ya3u99D7/FJquOIniQT1IKyDsBmEgwvpxMNeS65Oib7OnE2d2aY+3BU4OiH+0Wchf8yk3Hw=="
         },
         "@emotion/utils": {
             "version": "1.4.1",
@@ -8788,8 +8787,7 @@
         "@zag-js/date-utils": {
             "version": "0.77.1",
             "resolved": "https://registry.npmjs.org/@zag-js/date-utils/-/date-utils-0.77.1.tgz",
-            "integrity": "sha512-lPYI76n/PO2LZ+PVqgKqLZfYvpNTwOdGdbBFSkwBS7eUvleEd2/oi7AE1jJaKMZ3+Bf/zy1lM5e4dlY09xRFQw==",
-            "requires": {}
+            "integrity": "sha512-lPYI76n/PO2LZ+PVqgKqLZfYvpNTwOdGdbBFSkwBS7eUvleEd2/oi7AE1jJaKMZ3+Bf/zy1lM5e4dlY09xRFQw=="
         },
         "@zag-js/dialog": {
             "version": "0.77.1",
@@ -9359,8 +9357,7 @@
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
             "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "ajv": {
             "version": "6.12.6",
@@ -10119,8 +10116,7 @@
             "version": "9.1.0",
             "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
             "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "eslint-import-resolver-node": {
             "version": "0.3.9",
@@ -10273,15 +10269,13 @@
             "version": "4.6.0",
             "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
             "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "eslint-plugin-react-refresh": {
             "version": "0.4.5",
             "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.4.5.tgz",
             "integrity": "sha512-D53FYKJa+fDmZMtriODxvhwrO+IOqrxoEo21gMA0sjHdU6dPVH4OhyFip9ypl8HOF5RV5KdTo+rBQLvnY2cO8w==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "eslint-scope": {
             "version": "7.2.2",
@@ -11652,8 +11646,7 @@
         "react-icons": {
             "version": "5.4.0",
             "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.4.0.tgz",
-            "integrity": "sha512-7eltJxgVt7X64oHh6wSWNwwbKTCtMfK35hcjvJS0yxEAhPM8oUKdS3+kqaW1vicIltw+kR2unHaa12S9pPALoQ==",
-            "requires": {}
+            "integrity": "sha512-7eltJxgVt7X64oHh6wSWNwwbKTCtMfK35hcjvJS0yxEAhPM8oUKdS3+kqaW1vicIltw+kR2unHaa12S9pPALoQ=="
         },
         "react-is": {
             "version": "16.13.1",

--- a/src/utilities/links.jsx
+++ b/src/utilities/links.jsx
@@ -12,7 +12,7 @@ const linksAdmin = [
     { text: 'dashboard', path: '.', icon: <MdSpaceDashboard /> },
     { text: 'add employee', path: 'adduser', icon: <BsPersonFillAdd /> },
     { text: 'add product', path: 'add', icon: <IoAddCircle /> },
-    { text: 'dispense drug', path: 'dispense', icon: <AiFillMinusCircle /> },
+    // { text: 'dispense drug', path: 'dispense', icon: <AiFillMinusCircle /> },
     { text: 'alerts', path: 'alerts', icon: <TbBellFilled /> },
     { text: 'reports', path: 'reports', icon: <BsGraphUp /> },
     { text: 'past dispensed', path: 'past-orders', icon: <FaArrowCircleLeft /> },


### PR DESCRIPTION
## Description

1- I removed Dispense Drug as an option on the left menu, we could not use this functionality because on the backend we need the medication ID and that is unknown to the user. Now Dispense is only an option via the dashboard after clicking on a specific medication where the ID is then provided. 
